### PR TITLE
Safeguard watchlist removal when entry is missing

### DIFF
--- a/stock_web/db_creation.py
+++ b/stock_web/db_creation.py
@@ -87,9 +87,12 @@ def save_to_watchlist_db(ticker, user_id):
         db.session.commit()
 
 def remove_from_watchlist(ticker, user_id):
-    stonk_to_remove = db.session.query(Watchlist).filter(Watchlist.user_id == user_id, Watchlist.ticker == ticker).first()
-    db.session.delete(stonk_to_remove)
-    db.session.commit()
+    stonk_to_remove = db.session.query(Watchlist).filter(
+        Watchlist.user_id == user_id, Watchlist.ticker == ticker
+    ).first()
+    if stonk_to_remove is not None:
+        db.session.delete(stonk_to_remove)
+        db.session.commit()
 
 
 


### PR DESCRIPTION
## Summary
- Avoid attempting to delete a nonexistent watchlist entry

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d39d94f888326bf81c31fe1d58284