### PR TITLE
Fix watchlist route methods

### DIFF
--- a/stock_web/routes.py
+++ b/stock_web/routes.py
@@ -92,10 +92,16 @@ def deprocess():
 
 
 
-@app.route('/display_watchlist', methods=['post', 'GET'])
+@app.route('/display_watchlist', methods=['POST', 'GET'])
 def send_watchlist():
+    """Return the current user's watchlist.
+
+    Supports both GET and POST requests to make the endpoint more
+    flexible for different client-side interactions.
+    """
     user_watchlist = get_user_watchlist(current_user.id)
-    return user_watchlist
+    # ``jsonify`` ensures a valid Flask response object for both GET and POST
+    return jsonify(user_watchlist)
 #watchlist#
 
 


### PR DESCRIPTION
## Summary
- Ensure `/display_watchlist` endpoint accepts both POST and GET
- Return watchlist as JSON for consistent responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d3bd13d8c8326b088868f5cd6e856