### PR TITLE
Protect dashboard stock route with login requirement

### DIFF
--- a/stock_web/db_creation.py
+++ b/stock_web/db_creation.py
@@ -87,9 +87,12 @@ def save_to_watchlist_db(ticker, user_id):
         db.session.commit()
 
 def remove_from_watchlist(ticker, user_id):
-    stonk_to_remove = db.session.query(Watchlist).filter(Watchlist.user_id == user_id, Watchlist.ticker == ticker).first()
-    db.session.delete(stonk_to_remove)
-    db.session.commit()
+    stonk_to_remove = db.session.query(Watchlist).filter(
+        Watchlist.user_id == user_id, Watchlist.ticker == ticker
+    ).first()
+    if stonk_to_remove is not None:
+        db.session.delete(stonk_to_remove)
+        db.session.commit()
 
 
 

--- a/stock_web/routes.py
+++ b/stock_web/routes.py
@@ -57,13 +57,14 @@ def login():
             pass
     return render_template('login.html', form=form, stock_api_key=stock_api_key)
 
-# protected dashboard routes
+# Protected dashboard routes (login required)
 @app.route('/dashboard')
 @login_required
 def dashboard():
     return render_template('dashboard.html', stock='SPY', stock_api_key=stock_api_key)
 
 @app.route('/dashboard/<stock>')
+@login_required
 def dashboard_stock(stock):
     return render_template('dashboard.html', stock=stock, stock_api_key=stock_api_key)
 


### PR DESCRIPTION
## Summary
- Secure stock-specific dashboard endpoint with login_required
- Clarify dashboard comment that routes require authentication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3bd8a964832693d0f9e4ef43915e