### PR TITLE
Refactor to use blueprints and centralized configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class Config:
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL")
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    STOCK_API_KEY = os.getenv("STOCK_API_KEY")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/run.py
+++ b/run.py
@@ -1,5 +1,6 @@
-# init import
-from stock_web import app
+from stock_web import create_app
+
+app = create_app()
 
 
 

--- a/stock_web/__init__.py
+++ b/stock_web/__init__.py
@@ -1,24 +1,29 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
 from sqlalchemy.orm import DeclarativeBase
-from dotenv import load_dotenv
-import os
-load_dotenv()  # Loads the .env file
-database_url = os.getenv('DATABASE_URL')
-secret_key = os.getenv('SECRET_KEY')
+from config import Config
 
-app = Flask(__name__)
-app.config["SQLALCHEMY_DATABASE_URI"] = database_url
-app.config['SECRET_KEY'] = secret_key
-# Initialize SQLAlchemy database
+
 class Base(DeclarativeBase):
-  pass
+    pass
+
 
 db = SQLAlchemy(model_class=Base)
-db.init_app(app)  # Bind SQLAlchemy instance to the Flask app
+login_manager = LoginManager()
 
 
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
 
+    db.init_app(app)
+    login_manager.init_app(app)
 
+    from .routes import main_bp
+    app.register_blueprint(main_bp)
 
-from stock_web import routes
+    with app.app_context():
+        db.create_all()
+
+    return app

--- a/stock_web/db_creation.py
+++ b/stock_web/db_creation.py
@@ -87,9 +87,12 @@ def save_to_watchlist_db(ticker, user_id):
         db.session.commit()
 
 def remove_from_watchlist(ticker, user_id):
-    stonk_to_remove = db.session.query(Watchlist).filter(Watchlist.user_id == user_id, Watchlist.ticker == ticker).first()
-    db.session.delete(stonk_to_remove)
-    db.session.commit()
+    stonk_to_remove = db.session.query(Watchlist).filter(
+        Watchlist.user_id == user_id, Watchlist.ticker == ticker
+    ).first()
+    if stonk_to_remove is not None:
+        db.session.delete(stonk_to_remove)
+        db.session.commit()
 
 
 

--- a/stock_web/db_creation.py
+++ b/stock_web/db_creation.py
@@ -1,28 +1,22 @@
+from sqlalchemy import Integer, String, Column, ForeignKey
+from sqlalchemy.orm import relationship
+from flask_login import UserMixin
 
-from sqlalchemy import create_engine, Integer, String, Column, ForeignKey
-from sqlalchemy.orm import relationship, sessionmaker
-# look into user mixin 
-from flask_login import UserMixin, LoginManager, login_user, logout_user, login_required
-from flask_bcrypt import Bcrypt
+from . import db
 
-from . import db, app
 
-# creation of three database's 
-
-# holds user info 
 class User_cred(UserMixin, db.Model):
     __tablename__ = 'user_cred'
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(15), unique=True, nullable=False)
     user_email = db.Column(db.String(15), unique=True, nullable=False)
-    password_hash = db.Column(db.String(200),  nullable=False)
-    # Relationship to user_stock_info table
+    password_hash = db.Column(db.String(200), nullable=False)
     stock_info = relationship('User_notes', backref='user_cred', lazy=True)
-    watchlists = relationship('Watchlist', backref='user_cred', lazy=True) 
+    watchlists = relationship('Watchlist', backref='user_cred', lazy=True)
+
     def __repr__(self):
         return f'<User {self.username}>'
-    
-    # Flask-Login integration
+
     def is_authenticated(self):
         return True
 
@@ -34,14 +28,8 @@ class User_cred(UserMixin, db.Model):
 
     def get_id(self):
         return str(self.id)
-    
 
 
-
-
-
-
-# holds user notes on stocks
 class User_notes(db.Model):
     __tablename__ = 'user_notes'
     user_id = db.Column(db.Integer, ForeignKey('user_cred.id'), nullable=False, primary_key=True)
@@ -49,42 +37,29 @@ class User_notes(db.Model):
     ticker_notes = db.Column(db.String(10000), nullable=False)
 
 
-#holds the user's watchlist
 class Watchlist(db.Model):
     __tablename__ = 'watchlist'
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, ForeignKey('user_cred.id'), nullable=False)
-    ticker = db.Column(db.String(15), nullable=False) 
+    ticker = db.Column(db.String(15), nullable=False)
 
 
-with app.app_context():
-    db.create_all()
+# watchlist functions
 
-
-
-
-
-# watchlist #
-
-# functions for add and removing tickers to watchlist
 def check_if_already_in_watchlist(ticker, user_id):
     ticker_list = []
     user_tickers = db.session.query(Watchlist).filter(Watchlist.user_id == user_id).all()
     for tic in user_tickers:
         ticker_list.append(tic.ticker)
-    
-    if ticker in ticker_list:
-        return True
-    else:
-        return False
+    return ticker in ticker_list
 
- 
+
 def save_to_watchlist_db(ticker, user_id):
-
-    if check_if_already_in_watchlist(ticker, user_id) == False:
+    if not check_if_already_in_watchlist(ticker, user_id):
         new_record = Watchlist(user_id=user_id, ticker=ticker)
         db.session.add(new_record)
         db.session.commit()
+
 
 def remove_from_watchlist(ticker, user_id):
     stonk_to_remove = db.session.query(Watchlist).filter(
@@ -95,36 +70,28 @@ def remove_from_watchlist(ticker, user_id):
         db.session.commit()
 
 
-
 def get_user_watchlist(user_id):
-        ticker_list = []
-        user_tickers = db.session.query(Watchlist).filter(Watchlist.user_id == user_id).all()
-        for tic in user_tickers:
-            ticker_list.append(tic.ticker)
-        return ticker_list
+    ticker_list = []
+    user_tickers = db.session.query(Watchlist).filter(Watchlist.user_id == user_id).all()
+    for tic in user_tickers:
+        ticker_list.append(tic.ticker)
+    return ticker_list
 
 
-#watchlist #
+# note functions
 
-
-
-#notes#
-
-#fucntions for hadllineng the users notes
 def save_to_note_db(user_id, ticker, note):
-    if check_if_note_exist(user_id, ticker) == False:
+    if not check_if_note_exist(user_id, ticker):
         create_new_note(user_id, ticker, note)
     else:
         update_note(user_id, ticker, note)
 
 
 def check_if_note_exist(user_id, ticker):
-    check_note = db.session.query(User_notes).filter(User_notes.user_id == user_id, User_notes.ticker == ticker).first()
-    if check_note == None:
-        return False
-    else:
-        return True
-
+    check_note = db.session.query(User_notes).filter(
+        User_notes.user_id == user_id, User_notes.ticker == ticker
+    ).first()
+    return check_note is not None
 
 
 def create_new_note(user_id, ticker, note):
@@ -132,12 +99,11 @@ def create_new_note(user_id, ticker, note):
     db.session.add(new_record)
     db.session.commit()
 
+
 def update_note(user_id, ticker, note):
-    get_note = db.session.query(User_notes).filter(User_notes.user_id == user_id, User_notes.ticker == ticker).first()
+    get_note = db.session.query(User_notes).filter(
+        User_notes.user_id == user_id, User_notes.ticker == ticker
+    ).first()
     get_note.ticker_notes = note
     db.session.commit()
     print("succes from update ")
-
-
-        
-      

--- a/stock_web/routes.py
+++ b/stock_web/routes.py
@@ -1,142 +1,117 @@
-from flask import Flask, render_template, request , jsonify, url_for, redirect
-from flask_login import LoginManager, login_user, current_user, login_required, logout_user
+from flask import Blueprint, render_template, request, jsonify, url_for, redirect
+from flask_login import login_user, current_user, login_required, logout_user
 from werkzeug.security import generate_password_hash, check_password_hash
 
-from stock_web.forms import LoginForm, RegisterForm
-from .db_creation import User_cred,User_notes, save_to_watchlist_db, get_user_watchlist, check_if_already_in_watchlist, save_to_note_db, check_if_note_exist, remove_from_watchlist
-from dotenv import load_dotenv 
-from . import db, app
+from .forms import LoginForm, RegisterForm
+from .db_creation import (
+    User_cred,
+    User_notes,
+    save_to_watchlist_db,
+    get_user_watchlist,
+    save_to_note_db,
+    check_if_note_exist,
+    remove_from_watchlist,
+)
+from . import db, login_manager
 
 import os
 
-load_dotenv()  # Loads the .env file
-stock_api_key = os.getenv('STOCK_API_KEY') 
+stock_api_key = os.getenv("STOCK_API_KEY")
 
+main_bp = Blueprint("main", __name__)
 
-
-
-
-
-# Initialize the LoginManager and define the user loader function
-login_manager = LoginManager()
-login_manager.init_app(app)
 
 @login_manager.user_loader
 def load_user(user_id):
     return User_cred.query.get(int(user_id))
 
 
-# Registration Route:
-@app.route('/register', methods=['GET', 'POST'])
+@main_bp.route("/register", methods=["GET", "POST"])
 def register():
     form = RegisterForm()
-    print(form.username.data)
     if form.validate_on_submit():
         hashed_password = generate_password_hash(form.password.data)
-        
-        new_user = User_cred(username=form.username.data, user_email=form.email.data, password_hash=hashed_password)
+        new_user = User_cred(
+            username=form.username.data,
+            user_email=form.email.data,
+            password_hash=hashed_password,
+        )
         db.session.add(new_user)
         db.session.commit()
-        # Redirect to login page
-        return redirect(url_for('index'))
-    return render_template('register.html', form=form, stock_api_key=stock_api_key)
+        return redirect(url_for("main.index"))
+    return render_template("register.html", form=form, stock_api_key=stock_api_key)
 
 
-#login route 
-@app.route('/login', methods=['GET', 'POST'])
+@main_bp.route("/login", methods=["GET", "POST"])
 def login():
     form = LoginForm()
     if form.validate_on_submit():
         user = User_cred.query.filter_by(username=form.username.data).first()
         if user and check_password_hash(user.password_hash, form.password.data):
             login_user(user)
-            print("login succsesful")
-            return redirect(url_for('dashboard'))
-        else:
-            # Invalid login attempt
-            pass
-    return render_template('login.html', form=form, stock_api_key=stock_api_key)
+            return redirect(url_for("main.dashboard"))
+    return render_template("login.html", form=form, stock_api_key=stock_api_key)
 
-# protected dashboard routes
-@app.route('/dashboard')
+
+@main_bp.route("/dashboard")
 @login_required
 def dashboard():
-    return render_template('dashboard.html', stock='SPY', stock_api_key=stock_api_key)
+    return render_template("dashboard.html", stock="SPY", stock_api_key=stock_api_key)
 
-@app.route('/dashboard/<stock>')
+
+@main_bp.route("/dashboard/<stock>")
 def dashboard_stock(stock):
-    return render_template('dashboard.html', stock=stock, stock_api_key=stock_api_key)
+    return render_template("dashboard.html", stock=stock, stock_api_key=stock_api_key)
 
 
-#logout route
-@app.route('/logout', methods=['POST'])
+@main_bp.route("/logout", methods=["POST"])
 def logout():
     logout_user()
-    return redirect(url_for('index'))
+    return redirect(url_for("main.index"))
 
 
-
-#watchlist#
-@app.route('/add_watchlist', methods=['POST']) 
+@main_bp.route("/add_watchlist", methods=["POST"])
 def process():
-    ticker = request.form.get('data') 
+    ticker = request.form.get("data")
     save_to_watchlist_db(ticker, current_user.id)
     return "added to watchlist"
 
 
-@app.route('/remove_watchlist', methods=['POST']) 
+@main_bp.route("/remove_watchlist", methods=["POST"])
 def deprocess():
-    ticker = request.form.get('data') 
+    ticker = request.form.get("data")
     remove_from_watchlist(ticker, current_user.id)
     return "removed from watchlist"
 
 
-
-@app.route('/display_watchlist', methods=['POST', 'GET'])
+@main_bp.route("/display_watchlist", methods=["POST", "GET"])
 def send_watchlist():
-    """Return the current user's watchlist.
-
-    Supports both GET and POST requests to make the endpoint more
-    flexible for different client-side interactions.
-    """
     user_watchlist = get_user_watchlist(current_user.id)
-    # ``jsonify`` ensures a valid Flask response object for both GET and POST
     return jsonify(user_watchlist)
-#watchlist#
 
 
-#notes#
-@app.route('/get_note', methods=['POST'])
+@main_bp.route("/get_note", methods=["POST"])
 def get_note():
-    note = request.form.get('data')
-    user_id = request.form.get('user')
-    ticker = request.form.get('ticker')
+    note = request.form.get("data")
+    user_id = request.form.get("user")
+    ticker = request.form.get("ticker")
     save_to_note_db(user_id, ticker, note)
     return "good"
 
 
-
-@app.route('/display_note', methods=['POST', 'GET'])
+@main_bp.route("/display_note", methods=["POST", "GET"])
 def send_note():
-    user_id = request.form.get('user')
-    ticker = request.form.get('ticker')
-    if check_if_note_exist(user_id, ticker) == True:
-        query_note = db.session.query(User_notes).filter(User_notes.user_id == user_id, User_notes.ticker == ticker).first()
-        note = query_note.ticker_notes
-        return note
+    user_id = request.form.get("user")
+    ticker = request.form.get("ticker")
+    if check_if_note_exist(user_id, ticker):
+        query_note = db.session.query(User_notes).filter(
+            User_notes.user_id == user_id, User_notes.ticker == ticker
+        ).first()
+        return query_note.ticker_notes
     else:
         return ""
 
-    # need to get correct ticker and display
 
-
-
-
-@app.route('/')
+@main_bp.route("/")
 def index():
-    return render_template('index.html',  stock_api_key=stock_api_key)
-
-
-
-
-
+    return render_template("index.html", stock_api_key=stock_api_key)

--- a/stock_web/routes.py
+++ b/stock_web/routes.py
@@ -92,10 +92,16 @@ def deprocess():
 
 
 
-@app.route('/display_watchlist', methods=['post', 'GET'])
+@app.route('/display_watchlist', methods=['POST', 'GET'])
 def send_watchlist():
+    """Return the current user's watchlist.
+
+    Supports both GET and POST requests to make the endpoint more
+    flexible for different client-side interactions.
+    """
     user_watchlist = get_user_watchlist(current_user.id)
-    return user_watchlist
+    # ``jsonify`` ensures a valid Flask response object for both GET and POST
+    return jsonify(user_watchlist)
 #watchlist#
 
 

--- a/stock_web/templates/dashboard.html
+++ b/stock_web/templates/dashboard.html
@@ -249,7 +249,7 @@ function display_tickers(data){
     for(stonk of data){
         let name = stonk["2. name"]
         let sym = stonk["1. symbol"]
-        var flaskRouteURL = "{{ url_for('dashboard_stock',stock='' ) }}" + sym;
+        var flaskRouteURL = "{{ url_for('main.dashboard_stock',stock='' ) }}" + sym;
         $("#stock_load").append(`<a class="stock_display" href="${flaskRouteURL}">${name}</a><br>`);
     } }
     
@@ -469,7 +469,7 @@ function get_watchlist_data_from_db(){
 
 function display_watchlist(data){
     for(ticker of data){
-        var flaskRouteURL = "{{ url_for('dashboard_stock',stock='' ) }}" + ticker;
+        var flaskRouteURL = "{{ url_for('main.dashboard_stock',stock='' ) }}" + ticker;
         $("#watchlist").append(`<a   href="${flaskRouteURL}">${ticker}</a><br>`);
         }
     }

--- a/stock_web/templates/index.html
+++ b/stock_web/templates/index.html
@@ -10,8 +10,8 @@
 </div>
 
 <div id="choose_step">
-    <a href="{{ url_for('register') }}" id="create_user_button">create new acount</a> <br>
-    <a href="{{ url_for('login') }}" id="create_user_button">login</a>
+    <a href="{{ url_for('main.register') }}" id="create_user_button">create new acount</a> <br>
+    <a href="{{ url_for('main.login') }}" id="create_user_button">login</a>
 
 
 </div>

--- a/stock_web/templates/login.html
+++ b/stock_web/templates/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<form method="post" action="/login">
+<form method="post" action="{{ url_for('main.login') }}">
     <label for="username">Username:</label>
     <input type="text" id="username" name="username" required>
 

--- a/stock_web/templates/register.html
+++ b/stock_web/templates/register.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <!-- form to register -->
-<form  method="post" action="/register">
+<form  method="post" action="{{ url_for('main.register') }}">
     <label for="username">Username:</label>
     <input type="text" id="username" name="username" required>
 


### PR DESCRIPTION
## Summary
- add `config.py` for environment-based settings
- refactor Flask app into factory with SQLAlchemy and LoginManager initialization
- convert routes to a `main` blueprint and update templates accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'\nimport run\nprint('imported')\nPY` *(fails: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689d39d90bdc8326999f453501101d90